### PR TITLE
Update FARAO & OLF versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,10 @@
 
     <properties>
         <!-- Business projects version -->
-        <farao.core.version>4.4.1</farao.core.version>
+        <farao.core.version>4.5.0</farao.core.version>
         <powsybl.core.version>5.3.2</powsybl.core.version>
         <powsybl.entsoe.version>2.5.0</powsybl.entsoe.version>
-        <powsybl.open-loadflow.version>1.2.0</powsybl.open-loadflow.version>
+        <powsybl.open-loadflow.version>1.2.3</powsybl.open-loadflow.version>
         <powsybl.rte.core.version>3.11.0</powsybl.rte.core.version>
     </properties>
 


### PR DESCRIPTION
Update farao-core to 4.5.0
Update OLF to 1.2.3
WARNING : as of OLF v1.2.2, you have to use "throwsExceptionInCaseOfSlackDistributionFailure: true" to keep the same ehavior as before (see https://github.com/powsybl/powsybl-open-loadflow/releases/tag/v1.2.2)